### PR TITLE
fix: 在nodePolyfills配置中添加`crypto`模块

### DIFF
--- a/doocs.vite.config.ts
+++ b/doocs.vite.config.ts
@@ -21,7 +21,7 @@ export default {
     UnoCSS(),
     vueDevTools(),
     nodePolyfills({
-      include: [`path`, `util`, `timers`, `stream`, `fs`],
+      include: [`path`, `util`, `timers`, `stream`, `fs`, `crypto`],
       overrides: {
         // Since `fs` is not supported in browsers, we can use the `memfs` package to polyfill it.
         // fs: 'memfs',


### PR DESCRIPTION
解决mac build报错